### PR TITLE
chore: update .renovaterc.json

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -12,15 +12,13 @@
   "packageRules": [
     {
       "enabled": false,
-      "groupName": "nodejs",
       "matchDatasources": ["npm"],
       "matchPackageNames": ["@types/node"],
       "matchUpdateTypes": ["major"]
     },
     {
       "enabled": false,
-      "groupName": "nodejs",
-      "matchDatasources": ["docker"],
+      "matchDatasources": ["node-version"],
       "matchPackageNames": ["node"],
       "matchUpdateTypes": ["major"]
     },


### PR DESCRIPTION
## Summary
- Remove groupName from node package rules
- Use node-version datasource instead of docker for node